### PR TITLE
Fix error in catalogue number table

### DIFF
--- a/pages/tables/catalog-number-format-table.html
+++ b/pages/tables/catalog-number-format-table.html
@@ -1,143 +1,155 @@
 <table class="table table-sm">
   <colgroup>
-  <col width="270">
-  <col width="116">
-  <col width="*"></colgroup>
+    <col width="270">
+    <col width="116">
+    <col width="*">
+  </colgroup>
   <tbody>
-  <tr>
-  <th>Herbarium</th>
-  <th>Format</th>
-  <th>Description</th>
-  </tr>
-  <tr>
-  <td>State Herbarium of South Australia</td>
-  <td>AD 00000000</td>
-  <td>a number of up to nine digits, sometimes followed by a single letter</td>
-  </tr>
-  <tr>
-  <td></td>
-  <td>AD-A 00000(X)</td>
-  <td>a number of up to five digits, sometimes followed by a single letter</td>
-  </tr>
-  <tr>
-  <td></td>
-  <td>AD-C 00000(X)</td>
-  <td>a number of up to five digits, sometimes followed by a single letter</td>
-  </tr>
-  <tr>
-  <td>Auckland War Memorial Museum Herbarium</td>
-  <td>AK000000</td>
-  <td>a number of two to six digits, with no space after the herbarium code</td>
-  </tr>
-  <tr>
-  <td>Australian National Herbarium</td>
-  <td>CANB 000000</td>
-  <td>a number of up to six digits</td>
-  </tr>
-  <tr>
-  <td></td>
-  <td>CBG 0000000</td>
-  <td>a number of up to seven digits</td>
-  </tr>
-  <tr>
-  <td>University of Canterbury Herbarium</td>
-  <td>CANU 000000</td>
-  <td>a number of two to six digits, sometimes followed by a single letter</td>
-  </tr>
-  <tr>
-  <td>Allan Herbarium, Landcare Research NZ Ltd</td>
-  <td>CHR 000000</td>
-  <td>a a number of up to six digits, sometimes followed by a space and a letter</td>
-  </tr>
-  <tr>
-  <td>Australian Tropical Herbarium</td>
-  <td>CNS 000000</td>
-  <td>a number of up to six digits</td>
-  </tr>
-  <tr>
-  <td></td>
-  <td>QRS 000000</td>
-  <td>a number of up to six digits</td>
-  </tr>
-  <tr>
-  <td>Northern Territory Herbarium</td>
-  <td>DNA X0000000</td>
-  <td>a string of one letter followed by seven digits – the letter indicates whether the specimen originates from the Darwin Herbarium (D) or the Alice Springs Herbarium (A)</td>
-  </tr>
-  <tr>
-  <td>Tasmanian Herbarium</td>
-  <td>HO 000000</td>
-  <td>a number of up to six digits</td>
-  </tr>
-  <tr>
-  <td>James Cook University Herbarium</td>
-  <td>JCT JCT-X00000.0</td>
-  <td>a string of a single letter (indicating the major group to which the specimen belongs) followed by up to five digits, a full stop, then another digit; the herbarium code is repeated at the start of the catalogue number, and separated from the rest of the string by a hyphen</td>
-  </tr>
-  <tr>
-  <td>Lincoln University Herbarium</td>
-  <td>LINC-0000</td>
-  <td>a number of up to four digits, separated from the herbarium code by a hyphen (with no spaces)</td>
-  </tr>
-  <tr>
-  <td>La Trobe University Herbarium</td>
-  <td>HO 000000</td>
-  <td>a string of nine digits (with leading zeroes for numbers less than 100000000)</td>
-  </tr>
-  <tr>
-  <td>National Herbarium of Victoria</td>
-  <td>MEL 0000000X</td>
-  <td>a string of seven digits (with leading zeroes for numbers less than 1000000) followed by one letter</td>
-  </tr>
-  <tr>
-  <td>The University of Melbourne Herbarium</td>
-  <td>MELU X000000x</td>
-  <td>a string of a single letter (indicating the major group to which the specimen belongs) followed by six digits and a lower-case letter</td>
-  </tr>
-  <tr>
-  <td>Dame Ella Campbell Herbarium, Massey University</td>
-  <td>MPN 00000</td>
-  <td>a number of up to five digits</td>
-  </tr>
-  <tr>
-  <td>University of New England N.C.W. Beadle Herbarium</td>
-  <td>NE 000000</td>
-  <td>a number of one to six digits</td>
-  </tr>
-  <tr>
-  <td>National Herbarium of New South Wales</td>
-  <td>NSW 000000</td>
-  <td>a number of up to six digits</td>
-  </tr>
-  <tr>
-  <td>National Forestry Herbarium NZ</td>
-  <td>NZFRI 00000</td>
-  <td>a number of up to five digits</td>
-  </tr>
-  <tr>
-  <td>New Zealand Fungarium</td>
-  <td>PDD 000000</td>
-  <td>a string of six digits (with leading zeroes for numbers less than 100000)</td>
-  </tr>
-  <tr>
-  <td>Western Australian Herbarium</td>
-  <td>PERTH 0000000</td>
-  <td>a number of up to eight digits</td>
-  </tr>
-  <tr>
-  <td>Unitec Institute of Technology Herbarium</td>
-  <td>UNITEC 000000</td>
-  <td>a string of six digits (with leading zeroes for numbers less than 100000)</td>
-  </tr>
-  <tr>
-  <td>Herbarium of the Museum of New Zealand – Te Papa Tongarewa</td>
-  <td>WELT.X000000/X</td>
-  <td>a string of a single letter (indicating the major group to which the specimen belongs) followed by six digits (with leading zeroes for numbers less than 100000); the string is separated from the herbarium code by a full stop, and may be appended by a forward slash and a letter to indicate multiple parts</td>
-  </tr>
-  <tr>
-  <td>Janet Cosh Herbarium, University of Wollongong</td>
-  <td>MEL 0000000X</td>
-  <td>a number of up to five digits</td>
-  </tr>
+    <tr>
+      <th>Herbarium</th>
+      <th>Format</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td>State Herbarium of South Australia</td>
+      <td>AD 00000000</td>
+      <td>a number of up to nine digits, sometimes followed by a single letter</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>AD-A 00000(X)</td>
+      <td>a number of up to five digits, sometimes followed by a single letter</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>AD-C 00000(X)</td>
+      <td>a number of up to five digits, sometimes followed by a single letter</td>
+    </tr>
+    <tr>
+      <td>Auckland War Memorial Museum Herbarium</td>
+      <td>AK000000</td>
+      <td>a number of two to six digits, with no space after the herbarium code</td>
+    </tr>
+    <tr>
+      <td>Queensland Herbarium</td>
+      <td>BRI AQ0000000</td>
+      <td>a number of seven digits, prefixed with &apos;AQ&apos;</td>
+    </tr>
+    <tr>
+      <td>Australian National Herbarium</td>
+      <td>CANB 000000</td>
+      <td>a number of up to six digits</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>CBG 0000000</td>
+      <td>a number of up to seven digits</td>
+    </tr>
+    <tr>
+      <td>University of Canterbury Herbarium</td>
+      <td>CANU 000000</td>
+      <td>a number of two to six digits, sometimes followed by a single letter</td>
+    </tr>
+    <tr>
+      <td>Allan Herbarium, Landcare Research NZ Ltd</td>
+      <td>CHR 000000</td>
+      <td>a a number of up to six digits, sometimes followed by a space and a letter</td>
+    </tr>
+    <tr>
+      <td>Australian Tropical Herbarium</td>
+      <td>CNS 000000</td>
+      <td>a number of up to six digits</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>QRS 000000</td>
+      <td>a number of up to six digits</td>
+    </tr>
+    <tr>
+      <td>Northern Territory Herbarium</td>
+      <td>DNA X0000000</td>
+      <td>a string of one letter followed by seven digits – the letter indicates whether the specimen originates from
+        the Darwin Herbarium (D) or the Alice Springs Herbarium (A)</td>
+    </tr>
+    <tr>
+      <td>Tasmanian Herbarium</td>
+      <td>HO 000000</td>
+      <td>a number of up to six digits</td>
+    </tr>
+    <tr>
+      <td>James Cook University Herbarium</td>
+      <td>JCT JCT-X00000.0</td>
+      <td>a string of a single letter (indicating the major group to which the specimen belongs) followed by up to five
+        digits, a full stop, then another digit; the herbarium code is repeated at the start of the catalogue number,
+        and separated from the rest of the string by a hyphen</td>
+    </tr>
+    <tr>
+      <td>Lincoln University Herbarium</td>
+      <td>LINC-0000</td>
+      <td>a number of up to four digits, separated from the herbarium code by a hyphen (with no spaces)</td>
+    </tr>
+    <tr>
+      <td>La Trobe University Herbarium</td>
+      <td>HO 000000</td>
+      <td>a string of nine digits (with leading zeroes for numbers less than 100000000)</td>
+    </tr>
+    <tr>
+      <td>National Herbarium of Victoria</td>
+      <td>MEL 0000000X</td>
+      <td>a string of seven digits (with leading zeroes for numbers less than 1000000) followed by one letter</td>
+    </tr>
+    <tr>
+      <td>The University of Melbourne Herbarium</td>
+      <td>MELU X000000x</td>
+      <td>a string of a single letter (indicating the major group to which the specimen belongs) followed by six digits
+        and a lower-case letter</td>
+    </tr>
+    <tr>
+      <td>Dame Ella Campbell Herbarium, Massey University</td>
+      <td>MPN 00000</td>
+      <td>a number of up to five digits</td>
+    </tr>
+    <tr>
+      <td>University of New England N.C.W. Beadle Herbarium</td>
+      <td>NE 000000</td>
+      <td>a number of one to six digits</td>
+    </tr>
+    <tr>
+      <td>National Herbarium of New South Wales</td>
+      <td>NSW 000000</td>
+      <td>a number of up to six digits</td>
+    </tr>
+    <tr>
+      <td>National Forestry Herbarium NZ</td>
+      <td>NZFRI 00000</td>
+      <td>a number of up to five digits</td>
+    </tr>
+    <tr>
+      <td>New Zealand Fungarium</td>
+      <td>PDD 000000</td>
+      <td>a string of six digits (with leading zeroes for numbers less than 100000)</td>
+    </tr>
+    <tr>
+      <td>Western Australian Herbarium</td>
+      <td>PERTH 0000000</td>
+      <td>a number of up to eight digits</td>
+    </tr>
+    <tr>
+      <td>Unitec Institute of Technology Herbarium</td>
+      <td>UNITEC 000000</td>
+      <td>a string of six digits (with leading zeroes for numbers less than 100000)</td>
+    </tr>
+    <tr>
+      <td>Herbarium of the Museum of New Zealand – Te Papa Tongarewa</td>
+      <td>WELT.X000000/X</td>
+      <td>a string of a single letter (indicating the major group to which the specimen belongs) followed by six digits
+        (with leading zeroes for numbers less than 100000); the string is separated from the herbarium code by a full
+        stop, and may be appended by a forward slash and a letter to indicate multiple parts</td>
+    </tr>
+    <tr>
+      <td>Janet Cosh Herbarium, University of Wollongong</td>
+      <td>WOLL00000</td>
+      <td>a number of up to five digits, with no space after the herbarium code</td>
+    </tr>
   </tbody>
-  </table>
+</table>


### PR DESCRIPTION
Fixes #12

Added catalogue number format for Queensland Herbarium (BRI) and corrected catalogue number format for Janet Cosh Herbarium (WOLL). See https://hiscom.github.io/avh.chah.org.au/data/.